### PR TITLE
Convert to libadwaita

### DIFF
--- a/com.izzthedude.CoronaInfo.json
+++ b/com.izzthedude.CoronaInfo.json
@@ -12,6 +12,7 @@
     "--socket=wayland",
     "--socket=session-bus",
     "--filesystem=xdg-run/gvfsd",
+    "--filesystem=xdg-download",
     "--filesystem=~/.themes:ro",
     "--filesystem=/usr/share/themes:ro"
   ],

--- a/coronainfo/app.py
+++ b/coronainfo/app.py
@@ -21,7 +21,7 @@ import sys
 import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Gtk, Gio
+from gi.repository import Gio, Adw
 
 # noinspection PyUnresolvedReferences
 from coronainfo import _logger  # Unused but is necessary to initialise the logger
@@ -31,7 +31,7 @@ from coronainfo.views import MainWindow, AboutDialog
 from coronainfo.utils.ui_helpers import create_action, log_action_call
 
 
-class CoronaInfoApp(Gtk.Application):
+class CoronaInfoApp(Adw.Application):
     _schema = Gio.Settings(schema_id=App.ID)
     _settings = AppSettings.fetch_settings()
 

--- a/coronainfo/controllers/controller_main.py
+++ b/coronainfo/controllers/controller_main.py
@@ -17,6 +17,7 @@ class MainController(GObject.Object):
     POPULATE_FINISHED = "cube-helpless"
     PROGRESS_MESSAGE = "absurd-frosted"
     MODEL_EMPTY = "vintage-next"
+    TOAST_MESSAGE = "untwist-unicycle"
 
     def __init__(self):
         super().__init__()
@@ -49,7 +50,9 @@ class MainController(GObject.Object):
             self.model.clear()
             run_in_thread(self._populate_data, self.on_populate_finished, func_args=(False,))
         else:
-            logging.warning("Refresh in progress!")
+            message = "Refresh in progress!"
+            logging.warning(message)
+            self.emit(self.TOAST_MESSAGE, message, 2)
 
     def on_save(self, window: Gtk.ApplicationWindow):
         self._dialog = Gtk.FileChooserNative(
@@ -81,6 +84,10 @@ class MainController(GObject.Object):
 
             except GLib.Error as err:
                 logging.error("An error has occurred while trying to read from cache while saving:", exc_info=True)
+                self.emit(
+                    self.TOAST_MESSAGE,
+                    f"An error has occurred while attempting to save data. Refer the logs at {Paths.LOGS_DIR}",
+                    0)
 
         self._dialog.destroy()
 
@@ -100,6 +107,10 @@ class MainController(GObject.Object):
 
         except GLib.Error as err:
             logging.error("An error has occurred while trying to write data:", exc_info=True)
+            self.emit(
+                self.TOAST_MESSAGE,
+                f"An error has occurred while attempting to save data. Refer the logs at {Paths.LOGS_DIR}",
+                0)
 
     def on_write_file_complete(self, file: Gio.File, result: Gio.AsyncResult):
         result = file.replace_contents_finish(result)
@@ -109,7 +120,9 @@ class MainController(GObject.Object):
             logging.warning(f"Unable to save data to {path}")
             return
 
-        logging.info(f"Successfully saved data to {path}")
+        message = f"Successfully saved data to {path}"
+        logging.info(message)
+        self.emit(self.TOAST_MESSAGE, message, 2)
 
     def set_table(self, table: Gtk.TreeView):
         self.table = table
@@ -244,6 +257,10 @@ class MainController(GObject.Object):
 
         except GLib.Error as err:
             logging.error("An error has occurred while fetching data:", exc_info=True)
+            self.emit(
+                self.TOAST_MESSAGE,
+                f"An error has occurred while fetching data. Refer the logs at {Paths.LOGS_DIR}",
+                0)
 
     def _parse_table_html(self, table: Tag) -> map:
         countries: list[Tag] = table.find_all("tr")[7:]
@@ -301,6 +318,14 @@ class MainController(GObject.Object):
             GObject.SignalFlags.RUN_LAST,
             GObject.TYPE_BOOLEAN,
             []
+        )
+
+        GObject.signal_new(
+            self.TOAST_MESSAGE,
+            self,
+            GObject.SignalFlags.RUN_LAST,
+            GObject.TYPE_BOOLEAN,
+            [str, int]
         )
 
     def _bind_column_settings(self, column: Gtk.TreeViewColumn):

--- a/coronainfo/controllers/controller_main.py
+++ b/coronainfo/controllers/controller_main.py
@@ -16,6 +16,7 @@ class MainController(GObject.Object):
     POPULATE_STARTED = "velvet-massager"
     POPULATE_FINISHED = "cube-helpless"
     PROGRESS_MESSAGE = "absurd-frosted"
+    MODEL_EMPTY = "vintage-next"
 
     def __init__(self):
         super().__init__()
@@ -176,6 +177,9 @@ class MainController(GObject.Object):
             model_proxy: Gtk.TreeModelSort = Gtk.TreeModelSort.new_with_model(model_filter)
             self.table.set_model(model_proxy)
 
+            if len(model_proxy) == 0:
+                self.emit(self.MODEL_EMPTY)
+
     def visible_func(self, model: Gtk.ListStore, tree_iter: Gtk.TreeIter, data):
         if not self.country_filter:
             return True
@@ -289,6 +293,14 @@ class MainController(GObject.Object):
             GObject.SignalFlags.RUN_LAST,
             GObject.TYPE_BOOLEAN,
             [str]
+        )
+
+        GObject.signal_new(
+            self.MODEL_EMPTY,
+            self,
+            GObject.SignalFlags.RUN_LAST,
+            GObject.TYPE_BOOLEAN,
+            []
         )
 
     def _bind_column_settings(self, column: Gtk.TreeViewColumn):

--- a/coronainfo/enums.py
+++ b/coronainfo/enums.py
@@ -5,7 +5,7 @@ from pathlib import Path
 class App:
     ID = "com.izzthedude.CoronaInfo"
     NAME = "Corona Info"
-    VERSION = "0.2.2"
+    VERSION = "0.3.0"
     WEBSITE = "https://github.com/izzthedude/corona-info"
 
 

--- a/coronainfo/resources/ui/window_main.ui
+++ b/coronainfo/resources/ui/window_main.ui
@@ -6,6 +6,7 @@
     <property name="content">
       <object class="GtkBox">
         <property name="orientation">vertical</property>
+        <!-- Header Bar -->
         <child>
           <object class="AdwHeaderBar" id="header_bar">
             <child type="start">
@@ -43,55 +44,60 @@
             </child>
           </object>
         </child>
+        <!-- Main Content -->
         <child>
-          <object class="GtkBox" id="content_box">
+          <object class="AdwToastOverlay" id="toast_overlay">
             <child>
-              <object class="GtkBox" id="table_box">
-                <property name="orientation">vertical</property>
-                <property name="hexpand">true</property>
-                <property name="vexpand">true</property>
+              <object class="GtkBox" id="content_box">
                 <child>
-                  <object class="GtkSearchBar" id="searchbar">
-                    <child>
-                      <object class="GtkSearchEntry" id="search_entry">
-                        <property name="placeholder-text">Search...</property>
-                        <property name="tooltip-text">Search by country name</property>
-                        <signal name="search-changed" handler="on_search"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="AdwStatusPage" id="statuspage">
-                    <property name="visible">false</property>
+                  <object class="GtkBox" id="table_box">
+                    <property name="orientation">vertical</property>
+                    <property name="hexpand">true</property>
                     <property name="vexpand">true</property>
-                    <property name="icon-name">system-search-symbolic</property>
-                    <property name="title">No Results Found</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkScrolledWindow">
                     <child>
-                      <object class="GtkTreeView" id="table_view">
+                      <object class="GtkSearchBar" id="searchbar">
+                        <child>
+                          <object class="GtkSearchEntry" id="search_entry">
+                            <property name="placeholder-text">Search...</property>
+                            <property name="tooltip-text">Search by country name</property>
+                            <signal name="search-changed" handler="on_search"/>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwStatusPage" id="statuspage">
+                        <property name="visible">false</property>
                         <property name="vexpand">true</property>
-                        <property name="enable-search">false</property>
+                        <property name="icon-name">system-search-symbolic</property>
+                        <property name="title">No Results Found</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow">
+                        <child>
+                          <object class="GtkTreeView" id="table_view">
+                            <property name="vexpand">true</property>
+                            <property name="enable-search">false</property>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>
                 </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox" id="spinner_box">
-                <property name="hexpand">true</property>
-                <property name="vexpand">true</property>
-                <property name="valign">center</property>
-                <property name="halign">center</property>
                 <child>
-                  <object class="GtkSpinner" id="spinner">
-                    <property name="width-request">40</property>
-                    <property name="height-request">40</property>
-                    <property name="spinning">true</property>
+                  <object class="GtkBox" id="spinner_box">
+                    <property name="hexpand">true</property>
+                    <property name="vexpand">true</property>
+                    <property name="valign">center</property>
+                    <property name="halign">center</property>
+                    <child>
+                      <object class="GtkSpinner" id="spinner">
+                        <property name="width-request">40</property>
+                        <property name="height-request">40</property>
+                        <property name="spinning">true</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/coronainfo/resources/ui/window_main.ui
+++ b/coronainfo/resources/ui/window_main.ui
@@ -1,79 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <template class="MainWindow" parent="GtkApplicationWindow">
-    <property name="default-width">1200</property>
-    <property name="default-height">800</property>
-    <child type="titlebar">
-      <object class="GtkHeaderBar" id="header_bar">
-        <child type="start">
-          <object class="GtkBox" id="header_start_box">
-            <property name="spacing">5</property>
-            <child>
-              <object class="GtkButton" id="refresh_btn">
-                <property name="focus-on-click">false</property>
-                <property name="icon-name">view-refresh-symbolic</property>
-                <property name="tooltip-text">Refresh data</property>
-                <property name="action-name">win.refresh-data</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child type="end">
-          <object class="GtkBox" id="header_end_box">
-            <property name="spacing">5</property>
-            <child>
-              <object class="GtkToggleButton" id="search_btn">
-                <property name="focus-on-click">false</property>
-                <property name="icon-name">system-search-symbolic</property>
-                <property name="tooltip-text">Toggle search entry</property>
-                <property name="action-name">win.toggle-search</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuButton">
-                <property name="focus-on-click">false</property>
-                <property name="icon-name">open-menu-symbolic</property>
-                <property name="menu-model">primary_menu</property>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox" id="content_box">
+  <requires lib="adw" version="1.0"/>
+  <template class="MainWindow" parent="AdwApplicationWindow">
+    <property name="content">
+      <object class="GtkBox">
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkSearchBar" id="searchbar">
-            <child>
-              <object class="GtkSearchEntry" id="search_entry">
-                <property name="placeholder-text">Search...</property>
-                <property name="tooltip-text">Search by country name</property>
-                <signal name="search-changed" handler="on_search"/>
+          <object class="AdwHeaderBar" id="header_bar">
+            <child type="start">
+              <object class="GtkBox" id="header_start_box">
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkButton" id="refresh_btn">
+                    <property name="focus-on-click">false</property>
+                    <property name="icon-name">view-refresh-symbolic</property>
+                    <property name="tooltip-text">Refresh data</property>
+                    <property name="action-name">win.refresh-data</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="end">
+              <object class="GtkBox" id="header_end_box">
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkToggleButton" id="search_btn">
+                    <property name="focus-on-click">false</property>
+                    <property name="icon-name">system-search-symbolic</property>
+                    <property name="tooltip-text">Toggle search entry</property>
+                    <property name="action-name">win.toggle-search</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkMenuButton">
+                    <property name="focus-on-click">false</property>
+                    <property name="icon-name">open-menu-symbolic</property>
+                    <property name="menu-model">primary_menu</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkBox" id="content_box">
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkTreeView" id="table_view">
-                <property name="vexpand">true</property>
-                <property name="enable-search">false</property>
+              <object class="GtkSearchBar" id="searchbar">
+                <child>
+                  <object class="GtkSearchEntry" id="search_entry">
+                    <property name="placeholder-text">Search...</property>
+                    <property name="tooltip-text">Search by country name</property>
+                    <signal name="search-changed" handler="on_search"/>
+                  </object>
+                </child>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSpinner" id="spinner">
-            <property name="visible">false</property>
-            <property name="height-request">40</property>
-            <property name="spinning">true</property>
+            <child>
+              <object class="GtkScrolledWindow">
+                <child>
+                  <object class="GtkTreeView" id="table_view">
+                    <property name="vexpand">true</property>
+                    <property name="enable-search">false</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSpinner" id="spinner">
+                <property name="visible">false</property>
+                <property name="height-request">40</property>
+                <property name="spinning">true</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>
-    </child>
+    </property>
   </template>
 
   <menu id="primary_menu">
@@ -89,7 +93,7 @@
         <attribute name="action">win.preferences</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">_Keyboard shortcuts    </attribute>
+        <attribute name="label" translatable="yes">_Keyboard shortcuts</attribute>
         <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>

--- a/coronainfo/resources/ui/window_main.ui
+++ b/coronainfo/resources/ui/window_main.ui
@@ -62,6 +62,14 @@
                   </object>
                 </child>
                 <child>
+                  <object class="AdwStatusPage" id="statuspage">
+                    <property name="visible">false</property>
+                    <property name="vexpand">true</property>
+                    <property name="icon-name">system-search-symbolic</property>
+                    <property name="title">No Results Found</property>
+                  </object>
+                </child>
+                <child>
                   <object class="GtkScrolledWindow">
                     <child>
                       <object class="GtkTreeView" id="table_view">
@@ -75,7 +83,6 @@
             </child>
             <child>
               <object class="GtkBox" id="spinner_box">
-                <property name="visible">false</property>
                 <property name="hexpand">true</property>
                 <property name="vexpand">true</property>
                 <property name="valign">center</property>

--- a/coronainfo/resources/ui/window_main.ui
+++ b/coronainfo/resources/ui/window_main.ui
@@ -45,33 +45,48 @@
         </child>
         <child>
           <object class="GtkBox" id="content_box">
-            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkSearchBar" id="searchbar">
+              <object class="GtkBox" id="table_box">
+                <property name="orientation">vertical</property>
+                <property name="hexpand">true</property>
+                <property name="vexpand">true</property>
                 <child>
-                  <object class="GtkSearchEntry" id="search_entry">
-                    <property name="placeholder-text">Search...</property>
-                    <property name="tooltip-text">Search by country name</property>
-                    <signal name="search-changed" handler="on_search"/>
+                  <object class="GtkSearchBar" id="searchbar">
+                    <child>
+                      <object class="GtkSearchEntry" id="search_entry">
+                        <property name="placeholder-text">Search...</property>
+                        <property name="tooltip-text">Search by country name</property>
+                        <signal name="search-changed" handler="on_search"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <child>
+                      <object class="GtkTreeView" id="table_view">
+                        <property name="vexpand">true</property>
+                        <property name="enable-search">false</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
             </child>
             <child>
-              <object class="GtkScrolledWindow">
-                <child>
-                  <object class="GtkTreeView" id="table_view">
-                    <property name="vexpand">true</property>
-                    <property name="enable-search">false</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSpinner" id="spinner">
+              <object class="GtkBox" id="spinner_box">
                 <property name="visible">false</property>
-                <property name="height-request">40</property>
-                <property name="spinning">true</property>
+                <property name="hexpand">true</property>
+                <property name="vexpand">true</property>
+                <property name="valign">center</property>
+                <property name="halign">center</property>
+                <child>
+                  <object class="GtkSpinner" id="spinner">
+                    <property name="width-request">40</property>
+                    <property name="height-request">40</property>
+                    <property name="spinning">true</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/coronainfo/views/window_main.py
+++ b/coronainfo/views/window_main.py
@@ -38,6 +38,7 @@ class MainWindow(Adw.ApplicationWindow):
     table_box: Gtk.Box = Gtk.Template.Child(name="table_box")
     searchbar: Gtk.SearchBar = Gtk.Template.Child(name="searchbar")
     search_entry: Gtk.SearchEntry = Gtk.Template.Child(name="search_entry")
+    statuspage: Adw.StatusPage = Gtk.Template.Child(name="statuspage")
     table: Gtk.TreeView = Gtk.Template.Child(name="table_view")
 
     def __init__(self, **kwargs):
@@ -62,6 +63,7 @@ class MainWindow(Adw.ApplicationWindow):
         self.controller.connect(self.controller.POPULATE_STARTED, self.on_populate_started)
         self.controller.connect(self.controller.POPULATE_FINISHED, self.on_populate_finished)
         self.controller.connect(self.controller.PROGRESS_MESSAGE, self.on_progress_emitted)
+        self.controller.connect(self.controller.MODEL_EMPTY, self.on_model_empty)
         self.controller.start_populate()
 
     def on_populate_started(self, controller):
@@ -98,7 +100,13 @@ class MainWindow(Adw.ApplicationWindow):
 
     @Gtk.Template.Callback()
     def on_search(self, entry: Gtk.SearchEntry):
+        self.table.set_visible(True)
         self.controller.set_filter(entry.get_text())
+
+    def on_model_empty(self, controller):
+        search = self.search_entry.get_text()
+        self.statuspage.set_title(f"`{search}` Not Found")
+        self.statuspage.set_visible(True)
 
     def _init_settings(self):
         settings = app.get_schema()
@@ -135,6 +143,13 @@ class MainWindow(Adw.ApplicationWindow):
             self.searchbar,
             "search-mode-enabled",
             GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE
+        )
+
+        self.statuspage.bind_property(
+            "visible",
+            self.table,
+            "visible",
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.INVERT_BOOLEAN
         )
 
         self.spinner_box.bind_property(

--- a/coronainfo/views/window_main.py
+++ b/coronainfo/views/window_main.py
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+import os
+
 from gi.repository import Adw, GObject, Gio, Gtk
 
 from coronainfo import app
@@ -52,6 +55,10 @@ class MainWindow(Adw.ApplicationWindow):
         create_action(self, "save-data", self.on_save_action, ["<Ctrl>s"])
         create_action(self, "preferences", self.on_preferences_action, ["<Ctrl>comma"])
         create_action(self, "toggle-search", self.on_toggle_search_action)
+
+        if os.environ.get("CORONAINFO_DEBUG"):
+            create_action(self, "debug", self._on_debug_action, ["<Ctrl>d"])
+            logging.debug("Debug action created.")
 
         title = evaluate_title(app.get_settings())
         self.set_title(title)
@@ -113,6 +120,9 @@ class MainWindow(Adw.ApplicationWindow):
         search = self.search_entry.get_text()
         self.statuspage.set_title(f"`{search}` Not Found")
         self.statuspage.set_visible(True)
+
+    def _on_debug_action(self, action: Gio.SimpleAction, param):
+        logging.debug(f"Debug action activated")
 
     def _init_settings(self):
         settings = app.get_schema()

--- a/coronainfo/views/window_main.py
+++ b/coronainfo/views/window_main.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject, Gio, Gtk
+from gi.repository import Adw, GObject, Gio, Gtk
 
 from coronainfo import app
 from coronainfo.controllers import AppController
@@ -24,7 +24,7 @@ from coronainfo.views.dialog_preferences import PreferencesDialog
 
 
 @Gtk.Template(resource_path="/coronainfo/ui/main-window")
-class MainWindow(Gtk.ApplicationWindow):
+class MainWindow(Adw.ApplicationWindow):
     __gtype_name__ = "MainWindow"
 
     refresh_btn: Gtk.Button = Gtk.Template.Child(name="refresh_btn")

--- a/coronainfo/views/window_main.py
+++ b/coronainfo/views/window_main.py
@@ -28,42 +28,37 @@ class MainWindow(Adw.ApplicationWindow):
     __gtype_name__ = "MainWindow"
 
     refresh_btn: Gtk.Button = Gtk.Template.Child(name="refresh_btn")
-    spinner: Gtk.Spinner = Gtk.Template.Child(name="spinner")
     search_btn: Gtk.ToggleButton = Gtk.Template.Child(name="search_btn")
+
+    content_box: Gtk.Box = Gtk.Template.Child(name="content_box")
+
+    spinner_box: Gtk.Box = Gtk.Template.Child(name="spinner_box")
+    spinner: Gtk.Spinner = Gtk.Template.Child(name="spinner")
+
+    table_box: Gtk.Box = Gtk.Template.Child(name="table_box")
     searchbar: Gtk.SearchBar = Gtk.Template.Child(name="searchbar")
     search_entry: Gtk.SearchEntry = Gtk.Template.Child(name="search_entry")
-    content_box: Gtk.Box = Gtk.Template.Child(name="content_box")
     table: Gtk.TreeView = Gtk.Template.Child(name="table_view")
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._init_settings()
-
-        title = evaluate_title(app.get_settings())
-        self.set_title(title)
-
-        # Set the shortcuts window aka help overlay
-        builder: Gtk.Builder = Gtk.Builder.new_from_resource("/coronainfo/ui/help-overlay")
-        shortcuts_window: Gtk.ShortcutsWindow = builder.get_object("help_overlay")
-        self.set_help_overlay(shortcuts_window)
+        self._setup_help_overlay()
+        self._bind_properties()
 
         create_action(self, "refresh-data", self.on_refresh_action, ["<Ctrl>r"])
         create_action(self, "save-data", self.on_save_action, ["<Ctrl>s"])
         create_action(self, "preferences", self.on_preferences_action, ["<Ctrl>comma"])
         create_action(self, "toggle-search", self.on_toggle_search_action)
 
+        title = evaluate_title(app.get_settings())
+        self.set_title(title)
+
         self.searchbar.connect_entry(self.search_entry)
         self.searchbar.set_key_capture_widget(self)
-        self.searchbar.bind_property(
-            "search-mode-enabled",
-            self.search_btn,
-            "active",
-            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE
-        )
 
         self.controller = AppController.get_main_controller()
         self.controller.set_table(self.table)
-
         self.controller.connect(self.controller.POPULATE_STARTED, self.on_populate_started)
         self.controller.connect(self.controller.POPULATE_FINISHED, self.on_populate_finished)
         self.controller.connect(self.controller.PROGRESS_MESSAGE, self.on_progress_emitted)
@@ -71,18 +66,12 @@ class MainWindow(Adw.ApplicationWindow):
 
     def on_populate_started(self, controller):
         self.refresh_btn.set_sensitive(False)
-        self.searchbar.set_visible(False)
-        self.table.set_visible(False)
-        self.content_box.set_valign(Gtk.Align.CENTER)
-        self.spinner.set_visible(True)
+        self.spinner_box.set_visible(True)
         self.spinner.start()
 
     def on_populate_finished(self, controller):
         self.spinner.stop()
-        self.spinner.set_visible(False)
-        self.content_box.set_valign(Gtk.Align.FILL)
-        self.table.set_visible(True)
-        self.searchbar.set_visible(True)
+        self.spinner_box.set_visible(False)
         self.refresh_btn.set_sensitive(True)
 
     def on_progress_emitted(self, controller, message: str):
@@ -133,4 +122,24 @@ class MainWindow(Adw.ApplicationWindow):
             self,
             "maximized",
             Gio.SettingsBindFlags.DEFAULT
+        )
+
+    def _setup_help_overlay(self):
+        builder: Gtk.Builder = Gtk.Builder.new_from_resource("/coronainfo/ui/help-overlay")
+        shortcuts_window: Gtk.ShortcutsWindow = builder.get_object("help_overlay")
+        self.set_help_overlay(shortcuts_window)
+
+    def _bind_properties(self):
+        self.search_btn.bind_property(
+            "active",
+            self.searchbar,
+            "search-mode-enabled",
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE
+        )
+
+        self.spinner_box.bind_property(
+            "visible",
+            self.table_box,
+            "visible",
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.INVERT_BOOLEAN
         )

--- a/coronainfo/views/window_main.py
+++ b/coronainfo/views/window_main.py
@@ -30,6 +30,7 @@ class MainWindow(Adw.ApplicationWindow):
     refresh_btn: Gtk.Button = Gtk.Template.Child(name="refresh_btn")
     search_btn: Gtk.ToggleButton = Gtk.Template.Child(name="search_btn")
 
+    toast_overlay: Adw.ToastOverlay = Gtk.Template.Child(name="toast_overlay")
     content_box: Gtk.Box = Gtk.Template.Child(name="content_box")
 
     spinner_box: Gtk.Box = Gtk.Template.Child(name="spinner_box")
@@ -59,11 +60,12 @@ class MainWindow(Adw.ApplicationWindow):
         self.searchbar.set_key_capture_widget(self)
 
         self.controller = AppController.get_main_controller()
-        self.controller.set_table(self.table)
         self.controller.connect(self.controller.POPULATE_STARTED, self.on_populate_started)
         self.controller.connect(self.controller.POPULATE_FINISHED, self.on_populate_finished)
         self.controller.connect(self.controller.PROGRESS_MESSAGE, self.on_progress_emitted)
         self.controller.connect(self.controller.MODEL_EMPTY, self.on_model_empty)
+        self.controller.connect(self.controller.TOAST_MESSAGE, self.on_error_message)
+        self.controller.set_table(self.table)
         self.controller.start_populate()
 
     def on_populate_started(self, controller):
@@ -78,6 +80,10 @@ class MainWindow(Adw.ApplicationWindow):
 
     def on_progress_emitted(self, controller, message: str):
         self.set_title(message)
+
+    def on_error_message(self, controller, message: str, timeout: int = 0):
+        toast = Adw.Toast(title=message, timeout=timeout)
+        self.toast_overlay.add_toast(toast)
 
     def on_refresh_action(self, action: Gio.SimpleAction, param):
         log_action_call(action)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('coronainfo',
-          version: '0.2.2',
+          version: '0.3.0',
     meson_version: '>= 0.59.0',
   default_options: [ 'warning_level=2',
                      'werror=false',


### PR DESCRIPTION
## Description
Convert the application to use `libadwaita`, minor refactoring and add more UI elements.

### Using libadwaita
I decided to convert the application to use `libadwaita` cause... why not. It looks great and it's got some pretty cool widgets that make life easier for me. But then I realised this will probably either look weird or might not work as intended in non-Gnome DEs (GTK-based, obviously this will look funny in Qt-based DEs). So now I'm contemplating life and reflecting on all the decisions I've ever made in my life. I'm gonna keep it as `libadwaita` for now though since I've already made the effort lmao.

### Minor refactoring
'Minor refactoring' is just rearranging some code to look nicer to read lol. Am planning to do a sort of 'general cleanup' branch soon to deal with this kinda stuff but my fingers do be kinda itchy.

### More UI elements
I also added some UI elements for better user experience. This includes:
- A Status Page for when there are no results while searching
- A pop-up notification (or `ToastOverlay` in libadwaita) for displaying messages to the user

## Screenshots
Refer to [PR#2](https://github.com/izzthedude/corona-info/pull/2) to compare with the old look.

### Main View
![image](https://user-images.githubusercontent.com/63546762/190167467-6421f48b-5869-4db0-b7a0-0afa472249d3.png)

### No results????
![image](https://user-images.githubusercontent.com/63546762/190167556-de862040-1f2f-4e88-8d6b-e18e28a58b39.png)

### Pop-up notification aka ToastOverlay
![image](https://user-images.githubusercontent.com/63546762/190167743-f2a0896f-f1de-4ae7-bc4e-21dc9367ce21.png)
